### PR TITLE
Add file content and metadata functions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ func compareJSON(t *testing.T, got, want string) {
 - Environment functions: `env(name, default)` and `must_env(name)`
 - Hash functions: `md5(data)`, `sha1(data)`, `sha256(data)`, `sha512(data)` return hash as hexadecimal string
 - File hash functions: `md5_file(filename)`, `sha1_file(filename)`, `sha256_file(filename)`, `sha512_file(filename)` return file content hash as hexadecimal string
+- File functions: `file_content(filename)` returns file content as string, `file_stat(filename)` returns file metadata object
 
 ## Development Commands
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A Jsonnet rendering tool with additional useful functions.
 - Standard Jsonnet evaluation with external variables support
 - Built-in native functions for environment variable access
 - Hash functions for cryptographic operations
+- File functions for reading content and metadata
 
 ## Installation
 
@@ -93,6 +94,44 @@ local sha256_file = std.native("sha256_file");
 }
 ```
 
+### File Functions
+Access file content and metadata directly from Jsonnet.
+
+Available file functions:
+- `file_content(filename)`: Read file content as string
+- `file_stat(filename)`: Get file metadata as object
+
+```jsonnet
+local file_content = std.native("file_content");
+local file_stat = std.native("file_stat");
+
+{
+  // Read file content
+  config_content: file_content("/etc/config.json"),
+  readme: file_content("README.md"),
+  
+  // Parse JSON files directly
+  config: std.parseJson(file_content("/etc/config.json")),
+  
+  // Get file metadata
+  config_stat: file_stat("/etc/config.json"),
+  
+  // File information includes:
+  // - name: filename
+  // - size: file size in bytes
+  // - mode: file permissions as string
+  // - mod_time: modification time as Unix timestamp
+  // - is_dir: true if directory, false if regular file
+  
+  // Combine content and metadata
+  file_info: {
+    content: file_content("data.txt"),
+    stat: file_stat("data.txt"),
+    content_matches_size: std.length(file_content("data.txt")) == file_stat("data.txt").size
+  }
+}
+```
+
 ## Usage
 
 ```bash
@@ -133,6 +172,8 @@ local must_env = std.native("must_env");
 local md5 = std.native("md5");
 local sha256 = std.native("sha256");
 local sha256_file = std.native("sha256_file");
+local file_content = std.native("file_content");
+local file_stat = std.native("file_stat");
 
 {
   // External variables
@@ -152,6 +193,11 @@ local sha256_file = std.native("sha256_file");
   // File hash functions
   dockerfile_hash: sha256_file("Dockerfile"),
   config_file_integrity: sha256_file("/etc/app/config.yaml"),
+  
+  // File content and metadata
+  config: std.parseJson(file_content("/etc/app/config.json")),
+  config_modified: file_stat("/etc/app/config.json").mod_time,
+  is_large_config: file_stat("/etc/app/config.json").size > 1024,
 }
 ```
 

--- a/functions/file.go
+++ b/functions/file.go
@@ -1,0 +1,59 @@
+package functions
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/google/go-jsonnet"
+	"github.com/google/go-jsonnet/ast"
+)
+
+var FileFunctions = []*jsonnet.NativeFunction{
+	{
+		Name:   "file_content",
+		Params: []ast.Identifier{"filename"},
+		Func: func(args []any) (any, error) {
+			filename, ok := args[0].(string)
+			if !ok {
+				return nil, fmt.Errorf("file_content: filename must be a string")
+			}
+			
+			file, err := os.Open(filename)
+			if err != nil {
+				return nil, fmt.Errorf("file_content: failed to open file %s: %w", filename, err)
+			}
+			defer file.Close()
+			
+			content, err := io.ReadAll(file)
+			if err != nil {
+				return nil, fmt.Errorf("file_content: failed to read file %s: %w", filename, err)
+			}
+			
+			return string(content), nil
+		},
+	},
+	{
+		Name:   "file_stat",
+		Params: []ast.Identifier{"filename"},
+		Func: func(args []any) (any, error) {
+			filename, ok := args[0].(string)
+			if !ok {
+				return nil, fmt.Errorf("file_stat: filename must be a string")
+			}
+			
+			stat, err := os.Stat(filename)
+			if err != nil {
+				return nil, fmt.Errorf("file_stat: failed to stat file %s: %w", filename, err)
+			}
+			
+			return map[string]any{
+				"name":     stat.Name(),
+				"size":     stat.Size(),
+				"mode":     stat.Mode().String(),
+				"mod_time": stat.ModTime().Unix(),
+				"is_dir":   stat.IsDir(),
+			}, nil
+		},
+	},
+}

--- a/functions/file_test.go
+++ b/functions/file_test.go
@@ -1,0 +1,224 @@
+package functions_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/fujiwara/jsonnet-armed"
+)
+
+func TestFileFunctions(t *testing.T) {
+	ctx := context.Background()
+
+	// Create test files with known content
+	tmpDir := t.TempDir()
+	
+	// Create test file with simple content
+	helloFile := filepath.Join(tmpDir, "hello.txt")
+	helloContent := "Hello, World!"
+	if err := os.WriteFile(helloFile, []byte(helloContent), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+	
+	// Create test file with JSON content
+	jsonFile := filepath.Join(tmpDir, "test.json")
+	jsonContent := `{"message": "test", "number": 42}`
+	if err := os.WriteFile(jsonFile, []byte(jsonContent), 0644); err != nil {
+		t.Fatalf("failed to create JSON test file: %v", err)
+	}
+	
+	// Create test file with UTF-8 content
+	utf8File := filepath.Join(tmpDir, "utf8.txt")
+	utf8Content := "こんにちは、世界！"
+	if err := os.WriteFile(utf8File, []byte(utf8Content), 0644); err != nil {
+		t.Fatalf("failed to create UTF-8 test file: %v", err)
+	}
+	
+	// Create empty file
+	emptyFile := filepath.Join(tmpDir, "empty.txt")
+	if err := os.WriteFile(emptyFile, []byte(""), 0644); err != nil {
+		t.Fatalf("failed to create empty test file: %v", err)
+	}
+	
+	// Create a directory for testing
+	testDir := filepath.Join(tmpDir, "testdir")
+	if err := os.Mkdir(testDir, 0755); err != nil {
+		t.Fatalf("failed to create test directory: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		jsonnet     string
+		expected    string
+		expectError bool
+	}{
+		{
+			name: "file_content with simple text file",
+			jsonnet: fmt.Sprintf(`
+			local file_content = std.native("file_content");
+			{
+				content: file_content("%s")
+			}`, helloFile),
+			expected: `{
+				"content": "Hello, World!"
+			}`,
+		},
+		{
+			name: "file_content with JSON file",
+			jsonnet: fmt.Sprintf(`
+			local file_content = std.native("file_content");
+			{
+				raw_content: file_content("%s"),
+				parsed: std.parseJson(file_content("%s"))
+			}`, jsonFile, jsonFile),
+			expected: `{
+				"raw_content": "{\"message\": \"test\", \"number\": 42}",
+				"parsed": {
+					"message": "test",
+					"number": 42
+				}
+			}`,
+		},
+		{
+			name: "file_content with UTF-8 file",
+			jsonnet: fmt.Sprintf(`
+			local file_content = std.native("file_content");
+			{
+				content: file_content("%s")
+			}`, utf8File),
+			expected: `{
+				"content": "こんにちは、世界！"
+			}`,
+		},
+		{
+			name: "file_content with empty file",
+			jsonnet: fmt.Sprintf(`
+			local file_content = std.native("file_content");
+			{
+				content: file_content("%s"),
+				length: std.length(file_content("%s"))
+			}`, emptyFile, emptyFile),
+			expected: `{
+				"content": "",
+				"length": 0
+			}`,
+		},
+		{
+			name: "file_stat with regular file",
+			jsonnet: fmt.Sprintf(`
+			local file_stat = std.native("file_stat");
+			local stat = file_stat("%s");
+			{
+				name: stat.name,
+				size: stat.size,
+				is_dir: stat.is_dir,
+				has_mode: std.type(stat.mode) == "string",
+				has_mod_time: std.type(stat.mod_time) == "number"
+			}`, helloFile),
+			expected: `{
+				"name": "hello.txt",
+				"size": 13,
+				"is_dir": false,
+				"has_mode": true,
+				"has_mod_time": true
+			}`,
+		},
+		{
+			name: "file_stat with directory",
+			jsonnet: fmt.Sprintf(`
+			local file_stat = std.native("file_stat");
+			local stat = file_stat("%s");
+			{
+				name: stat.name,
+				is_dir: stat.is_dir,
+				has_mode: std.type(stat.mode) == "string"
+			}`, testDir),
+			expected: `{
+				"name": "testdir",
+				"is_dir": true,
+				"has_mode": true
+			}`,
+		},
+		{
+			name: "combining file_content and file_stat",
+			jsonnet: fmt.Sprintf(`
+			local file_content = std.native("file_content");
+			local file_stat = std.native("file_stat");
+			local content = file_content("%s");
+			local stat = file_stat("%s");
+			{
+				content: content,
+				content_length: std.length(content),
+				file_size: stat.size,
+				size_matches: std.length(content) == stat.size
+			}`, helloFile, helloFile),
+			expected: `{
+				"content": "Hello, World!",
+				"content_length": 13,
+				"file_size": 13,
+				"size_matches": true
+			}`,
+		},
+		{
+			name: "file_content with non-existent file",
+			jsonnet: `
+			local file_content = std.native("file_content");
+			{
+				content: file_content("/non/existent/file.txt")
+			}`,
+			expectError: true,
+		},
+		{
+			name: "file_stat with non-existent file",
+			jsonnet: `
+			local file_stat = std.native("file_stat");
+			{
+				stat: file_stat("/non/existent/file.txt")
+			}`,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temp file with jsonnet content
+			tmpDir := t.TempDir()
+			jsonnetFile := filepath.Join(tmpDir, "test.jsonnet")
+			if err := os.WriteFile(jsonnetFile, []byte(tt.jsonnet), 0644); err != nil {
+				t.Fatalf("failed to write jsonnet file: %v", err)
+			}
+
+			// Create CLI config
+			cli := &armed.CLI{
+				Filename: jsonnetFile,
+			}
+
+			// Capture output
+			var output bytes.Buffer
+			armed.SetOutput(&output)
+			defer armed.SetOutput(os.Stdout)
+
+			// Run evaluation
+			err := armed.RunWithCLI(ctx, cli)
+
+			// Check error expectation
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// Compare JSON output
+			compareJSON(t, output.String(), tt.expected)
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -39,6 +39,9 @@ func run(ctx context.Context, cli *CLI) error {
 	for _, f := range functions.HashFunctions {
 		vm.NativeFunction(f)
 	}
+	for _, f := range functions.FileFunctions {
+		vm.NativeFunction(f)
+	}
 
 	for k, v := range cli.ExtStr {
 		vm.ExtVar(k, v)


### PR DESCRIPTION
## Summary
- Add `file_content(filename)` function to read file content as string
- Add `file_stat(filename)` function to get file metadata object
- Support UTF-8 content and comprehensive file information
- Proper error handling for non-existent files

## Test plan
- [x] All existing tests pass
- [x] File content function tests pass
- [x] File stat function tests pass  
- [x] UTF-8 content support verified
- [x] Error handling tested (non-existent files)
- [x] Integration with std.parseJson() tested

🤖 Generated with [Claude Code](https://claude.ai/code)