### PR TITLE
Add base64 encoding functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,36 @@ local must_env = std.native("must_env");
 }
 ```
 
+### Base64 Functions
+Encode strings to Base64 format.
+
+Available base64 functions:
+- `base64(data)`: Standard Base64 encoding
+- `base64url(data)`: URL-safe Base64 encoding (uses `-` and `_` instead of `+` and `/`)
+
+```jsonnet
+local base64 = std.native("base64");
+local base64url = std.native("base64url");
+
+{
+  // Standard Base64 encoding
+  encoded: base64("Hello, World!"),        // "SGVsbG8sIFdvcmxkIQ=="
+  empty: base64(""),                       // ""
+  
+  // URL-safe Base64 encoding  
+  url_safe: base64url("??>>"),             // "Pz8-Pg==" (uses - instead of +)
+  
+  // Encoding JSON data
+  json_encoded: base64(std.manifestJsonEx({ 
+    user: "admin", 
+    timestamp: 1234567890 
+  }, "")),
+  
+  // Encoding with special characters
+  unicode: base64("こんにちは世界"),        // "44GT44KT44Gr44Gh44Gv5LiW55WM"
+}
+```
+
 ### Hash Functions
 Calculate hash of the given string or file and return it as hexadecimal string.
 

--- a/functions/armed.go
+++ b/functions/armed.go
@@ -12,6 +12,7 @@ func AllFunctions() []*jsonnet.NativeFunction {
 	all = append(all, EnvFunctions...)
 	all = append(all, HashFunctions...)
 	all = append(all, FileFunctions...)
+	all = append(all, Base64Functions...)
 	return all
 }
 

--- a/functions/armed_test.go
+++ b/functions/armed_test.go
@@ -16,6 +16,8 @@ func TestGenerateArmedLib(t *testing.T) {
 		"must_env: std.native('must_env')",
 		"md5: std.native('md5')",
 		"file_stat: std.native('file_stat')",
+		"base64: std.native('base64')",
+		"base64url: std.native('base64url')",
 	}
 
 	for _, expected := range expectedFunctions {

--- a/functions/base64.go
+++ b/functions/base64.go
@@ -1,0 +1,34 @@
+package functions
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"github.com/google/go-jsonnet"
+	"github.com/google/go-jsonnet/ast"
+)
+
+var Base64Functions = []*jsonnet.NativeFunction{
+	{
+		Name:   "base64",
+		Params: []ast.Identifier{"data"},
+		Func: func(args []any) (any, error) {
+			data, ok := args[0].(string)
+			if !ok {
+				return nil, fmt.Errorf("base64: data must be a string")
+			}
+			return base64.StdEncoding.EncodeToString([]byte(data)), nil
+		},
+	},
+	{
+		Name:   "base64url",
+		Params: []ast.Identifier{"data"},
+		Func: func(args []any) (any, error) {
+			data, ok := args[0].(string)
+			if !ok {
+				return nil, fmt.Errorf("base64url: data must be a string")
+			}
+			return base64.URLEncoding.EncodeToString([]byte(data)), nil
+		},
+	},
+}

--- a/functions/base64_test.go
+++ b/functions/base64_test.go
@@ -1,0 +1,162 @@
+package functions_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/fujiwara/jsonnet-armed"
+)
+
+func TestBase64Functions(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		jsonnet     string
+		expected    string
+		expectError bool
+	}{
+		{
+			name: "base64 encode simple string",
+			jsonnet: `
+			local base64 = std.native("base64");
+			base64("Hello, World!")`,
+			expected: `"SGVsbG8sIFdvcmxkIQ=="`,
+		},
+		{
+			name: "base64 encode empty string",
+			jsonnet: `
+			local base64 = std.native("base64");
+			base64("")`,
+			expected: `""`,
+		},
+		{
+			name: "base64 encode special characters",
+			jsonnet: `
+			local base64 = std.native("base64");
+			base64("The quick brown fox jumps over the lazy dog")`,
+			expected: `"VGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5IGRvZw=="`,
+		},
+		{
+			name: "base64url encode simple string",
+			jsonnet: `
+			local base64url = std.native("base64url");
+			base64url("Hello, World!")`,
+			expected: `"SGVsbG8sIFdvcmxkIQ=="`,
+		},
+		{
+			name: "base64url encode with URL-unsafe characters",
+			jsonnet: `
+			local base64url = std.native("base64url");
+			base64url("??>>")`,
+			expected: `"Pz8-Pg=="`,
+		},
+		{
+			name: "base64 vs base64url difference",
+			jsonnet: `
+			local base64 = std.native("base64");
+			local base64url = std.native("base64url");
+			{
+				standard: base64("??>>"),
+				urlsafe: base64url("??>>")
+			}`,
+			expected: `{
+				"standard": "Pz8+Pg==",
+				"urlsafe": "Pz8-Pg=="
+			}`,
+		},
+		{
+			name: "base64 with non-string input",
+			jsonnet: `
+			local base64 = std.native("base64");
+			base64(123)`,
+			expectError: true,
+		},
+		{
+			name: "base64url with non-string input",
+			jsonnet: `
+			local base64url = std.native("base64url");
+			base64url(123)`,
+			expectError: true,
+		},
+		{
+			name: "base64 encode unicode string",
+			jsonnet: `
+			local base64 = std.native("base64");
+			base64("こんにちは世界")`,
+			expected: `"44GT44KT44Gr44Gh44Gv5LiW55WM"`,
+		},
+		{
+			name: "base64 functions with jsonnet logic",
+			jsonnet: `
+			local base64 = std.native("base64");
+			local data = "test-data";
+			local encoded = base64(data);
+			{
+				original: data,
+				encoded: encoded,
+				length: std.length(encoded)
+			}`,
+			expected: `{
+				"original": "test-data",
+				"encoded": "dGVzdC1kYXRh",
+				"length": 12
+			}`,
+		},
+		{
+			name: "armed library import with base64",
+			jsonnet: `
+			local armed = import 'armed.libsonnet';
+			{
+				base64: armed.base64("hello"),
+				base64url: armed.base64url("hello")
+			}`,
+			expected: `{
+				"base64": "aGVsbG8=",
+				"base64url": "aGVsbG8="
+			}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temp file with jsonnet content
+			tmpDir := t.TempDir()
+			jsonnetFile := filepath.Join(tmpDir, "test.jsonnet")
+			if err := os.WriteFile(jsonnetFile, []byte(tt.jsonnet), 0644); err != nil {
+				t.Fatalf("failed to write jsonnet file: %v", err)
+			}
+
+			// Create CLI config
+			cli := &armed.CLI{
+				Filename: jsonnetFile,
+			}
+
+			// Capture output
+			var output bytes.Buffer
+			armed.SetOutput(&output)
+			defer armed.SetOutput(os.Stdout)
+
+			// Run evaluation
+			err := armed.RunWithCLI(ctx, cli)
+
+			// Check error expectation
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// Compare JSON output
+			compareJSON(t, output.String(), tt.expected)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add `base64()` function for standard Base64 encoding
- Add `base64url()` function for URL-safe Base64 encoding

## Details
This PR adds two new native functions for Base64 encoding:

1. **`base64(data)`**: Standard Base64 encoding that accepts a string and returns the Base64-encoded result
2. **`base64url(data)`**: URL-safe Base64 encoding that uses `-` and `_` instead of `+` and `/`

Both functions:
- Accept string input only (return error for non-string values)
- Support Unicode strings
- Are available through the `armed.libsonnet` library

## Test plan
- [x] Added comprehensive unit tests in `functions/base64_test.go`
- [x] Tests cover various scenarios including empty strings, special characters, Unicode
- [x] All existing tests pass
- [x] Manual testing via CLI confirmed working

🤖 Generated with [Claude Code](https://claude.ai/code)