### PR TITLE
Refactor native functions from slices to maps for O(1) access

### DIFF
--- a/functions/armed.go
+++ b/functions/armed.go
@@ -9,11 +9,24 @@ import (
 // AllFunctions returns all native functions in one slice
 func AllFunctions() []*jsonnet.NativeFunction {
 	var all []*jsonnet.NativeFunction
-	all = append(all, EnvFunctions...)
-	all = append(all, HashFunctions...)
-	all = append(all, FileFunctions...)
-	all = append(all, Base64Functions...)
-	all = append(all, TimeFunctions...)
+
+	// Add functions from maps
+	for _, f := range EnvFunctions {
+		all = append(all, f)
+	}
+	for _, f := range HashFunctions {
+		all = append(all, f)
+	}
+	for _, f := range FileFunctions {
+		all = append(all, f)
+	}
+	for _, f := range Base64Functions {
+		all = append(all, f)
+	}
+	for _, f := range TimeFunctions {
+		all = append(all, f)
+	}
+
 	return all
 }
 

--- a/functions/base64.go
+++ b/functions/base64.go
@@ -8,9 +8,8 @@ import (
 	"github.com/google/go-jsonnet/ast"
 )
 
-var Base64Functions = []*jsonnet.NativeFunction{
-	{
-		Name:   "base64",
+var Base64Functions = map[string]*jsonnet.NativeFunction{
+	"base64": {
 		Params: []ast.Identifier{"data"},
 		Func: func(args []any) (any, error) {
 			data, ok := args[0].(string)
@@ -20,8 +19,7 @@ var Base64Functions = []*jsonnet.NativeFunction{
 			return base64.StdEncoding.EncodeToString([]byte(data)), nil
 		},
 	},
-	{
-		Name:   "base64url",
+	"base64url": {
 		Params: []ast.Identifier{"data"},
 		Func: func(args []any) (any, error) {
 			data, ok := args[0].(string)
@@ -31,4 +29,8 @@ var Base64Functions = []*jsonnet.NativeFunction{
 			return base64.URLEncoding.EncodeToString([]byte(data)), nil
 		},
 	},
+}
+
+func init() {
+	initializeFunctionMap(Base64Functions)
 }

--- a/functions/env.go
+++ b/functions/env.go
@@ -8,9 +8,8 @@ import (
 	"github.com/google/go-jsonnet/ast"
 )
 
-var EnvFunctions = []*jsonnet.NativeFunction{
-	{
-		Name:   "env",
+var EnvFunctions = map[string]*jsonnet.NativeFunction{
+	"env": {
 		Params: []ast.Identifier{"name", "default"},
 		Func: func(args []any) (any, error) {
 			key, ok := args[0].(string)
@@ -23,8 +22,7 @@ var EnvFunctions = []*jsonnet.NativeFunction{
 			return args[1], nil
 		},
 	},
-	{
-		Name:   "must_env",
+	"must_env": {
 		Params: []ast.Identifier{"name"},
 		Func: func(args []any) (any, error) {
 			key, ok := args[0].(string)
@@ -37,4 +35,8 @@ var EnvFunctions = []*jsonnet.NativeFunction{
 			return nil, fmt.Errorf("must_env: %s is not set", key)
 		},
 	},
+}
+
+func init() {
+	initializeFunctionMap(EnvFunctions)
 }

--- a/functions/file.go
+++ b/functions/file.go
@@ -9,9 +9,8 @@ import (
 	"github.com/google/go-jsonnet/ast"
 )
 
-var FileFunctions = []*jsonnet.NativeFunction{
-	{
-		Name:   "file_content",
+var FileFunctions = map[string]*jsonnet.NativeFunction{
+	"file_content": {
 		Params: []ast.Identifier{"filename"},
 		Func: func(args []any) (any, error) {
 			filename, ok := args[0].(string)
@@ -33,8 +32,7 @@ var FileFunctions = []*jsonnet.NativeFunction{
 			return string(content), nil
 		},
 	},
-	{
-		Name:   "file_stat",
+	"file_stat": {
 		Params: []ast.Identifier{"filename"},
 		Func: func(args []any) (any, error) {
 			filename, ok := args[0].(string)
@@ -56,8 +54,7 @@ var FileFunctions = []*jsonnet.NativeFunction{
 			}, nil
 		},
 	},
-	{
-		Name:   "file_exists",
+	"file_exists": {
 		Params: []ast.Identifier{"filename"},
 		Func: func(args []any) (any, error) {
 			filename, ok := args[0].(string)
@@ -69,4 +66,8 @@ var FileFunctions = []*jsonnet.NativeFunction{
 			return err == nil, nil
 		},
 	},
+}
+
+func init() {
+	initializeFunctionMap(FileFunctions)
 }

--- a/functions/hash.go
+++ b/functions/hash.go
@@ -16,59 +16,79 @@ import (
 )
 
 // hashFunction creates a generic hash function using the hash.Hash interface
-func hashFunction(name string, newHasher func() hash.Hash) *jsonnet.NativeFunction {
-	return &jsonnet.NativeFunction{
-		Name:   name,
-		Params: []ast.Identifier{"data"},
-		Func: func(args []any) (any, error) {
-			data, ok := args[0].(string)
-			if !ok {
-				return nil, fmt.Errorf("%s: data must be a string", name)
-			}
-			hasher := newHasher()
-			hasher.Write([]byte(data))
-			return hex.EncodeToString(hasher.Sum(nil)), nil
-		},
+func hashFunction(newHasher func() hash.Hash) func([]any) (any, error) {
+	return func(args []any) (any, error) {
+		data, ok := args[0].(string)
+		if !ok {
+			return nil, fmt.Errorf("data must be a string")
+		}
+		hasher := newHasher()
+		hasher.Write([]byte(data))
+		return hex.EncodeToString(hasher.Sum(nil)), nil
 	}
 }
 
 // hashFileFunction creates a generic file hash function using the hash.Hash interface
-func hashFileFunction(name string, newHasher func() hash.Hash) *jsonnet.NativeFunction {
-	return &jsonnet.NativeFunction{
-		Name:   name,
-		Params: []ast.Identifier{"filename"},
-		Func: func(args []any) (any, error) {
-			filename, ok := args[0].(string)
-			if !ok {
-				return nil, fmt.Errorf("%s: filename must be a string", name)
-			}
+func hashFileFunction(newHasher func() hash.Hash) func([]any) (any, error) {
+	return func(args []any) (any, error) {
+		filename, ok := args[0].(string)
+		if !ok {
+			return nil, fmt.Errorf("filename must be a string")
+		}
 
-			file, err := os.Open(filename)
-			if err != nil {
-				return nil, fmt.Errorf("%s: failed to open file %s: %w", name, filename, err)
-			}
-			defer file.Close()
+		file, err := os.Open(filename)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open file %s: %w", filename, err)
+		}
+		defer file.Close()
 
-			hasher := newHasher()
-			if _, err := io.Copy(hasher, file); err != nil {
-				return nil, fmt.Errorf("%s: failed to read file %s: %w", name, filename, err)
-			}
+		hasher := newHasher()
+		if _, err := io.Copy(hasher, file); err != nil {
+			return nil, fmt.Errorf("failed to read file %s: %w", filename, err)
+		}
 
-			return hex.EncodeToString(hasher.Sum(nil)), nil
-		},
+		return hex.EncodeToString(hasher.Sum(nil)), nil
 	}
 }
 
-var HashFunctions = []*jsonnet.NativeFunction{
+var HashFunctions = map[string]*jsonnet.NativeFunction{
 	// String hash functions
-	hashFunction("md5", func() hash.Hash { return md5.New() }),
-	hashFunction("sha1", func() hash.Hash { return sha1.New() }),
-	hashFunction("sha256", func() hash.Hash { return sha256.New() }),
-	hashFunction("sha512", func() hash.Hash { return sha512.New() }),
+	"md5": {
+		Params: []ast.Identifier{"data"},
+		Func:   hashFunction(func() hash.Hash { return md5.New() }),
+	},
+	"sha1": {
+		Params: []ast.Identifier{"data"},
+		Func:   hashFunction(func() hash.Hash { return sha1.New() }),
+	},
+	"sha256": {
+		Params: []ast.Identifier{"data"},
+		Func:   hashFunction(func() hash.Hash { return sha256.New() }),
+	},
+	"sha512": {
+		Params: []ast.Identifier{"data"},
+		Func:   hashFunction(func() hash.Hash { return sha512.New() }),
+	},
 
 	// File hash functions
-	hashFileFunction("md5_file", func() hash.Hash { return md5.New() }),
-	hashFileFunction("sha1_file", func() hash.Hash { return sha1.New() }),
-	hashFileFunction("sha256_file", func() hash.Hash { return sha256.New() }),
-	hashFileFunction("sha512_file", func() hash.Hash { return sha512.New() }),
+	"md5_file": {
+		Params: []ast.Identifier{"filename"},
+		Func:   hashFileFunction(func() hash.Hash { return md5.New() }),
+	},
+	"sha1_file": {
+		Params: []ast.Identifier{"filename"},
+		Func:   hashFileFunction(func() hash.Hash { return sha1.New() }),
+	},
+	"sha256_file": {
+		Params: []ast.Identifier{"filename"},
+		Func:   hashFileFunction(func() hash.Hash { return sha256.New() }),
+	},
+	"sha512_file": {
+		Params: []ast.Identifier{"filename"},
+		Func:   hashFileFunction(func() hash.Hash { return sha512.New() }),
+	},
+}
+
+func init() {
+	initializeFunctionMap(HashFunctions)
 }

--- a/functions/helpers.go
+++ b/functions/helpers.go
@@ -1,0 +1,12 @@
+package functions
+
+import (
+	"github.com/google/go-jsonnet"
+)
+
+// initializeFunctionMap sets the Name field for all functions based on their map keys
+func initializeFunctionMap(functionMap map[string]*jsonnet.NativeFunction) {
+	for name, function := range functionMap {
+		function.Name = name
+	}
+}

--- a/functions/test_helpers_test.go
+++ b/functions/test_helpers_test.go
@@ -4,36 +4,45 @@ import (
 	"fmt"
 
 	"github.com/fujiwara/jsonnet-armed/functions"
-	"github.com/google/go-jsonnet"
 )
 
-// getFunctionByName returns a native function by its name from the given function list
-func getFunctionByName(funcs []*jsonnet.NativeFunction, name string) (func([]any) (any, error), error) {
-	for _, f := range funcs {
-		if f.Name == name {
-			return f.Func, nil
-		}
-	}
-	return nil, fmt.Errorf("function %s not found", name)
-}
-
-// Helper functions to get specific functions by name
+// Helper functions to get specific functions by name from maps
 func getEnvFunction(name string) (func([]any) (any, error), error) {
-	return getFunctionByName(functions.EnvFunctions, name)
+	f, ok := functions.EnvFunctions[name]
+	if !ok {
+		return nil, fmt.Errorf("env function %s not found", name)
+	}
+	return f.Func, nil
 }
 
 func getBase64Function(name string) (func([]any) (any, error), error) {
-	return getFunctionByName(functions.Base64Functions, name)
+	f, ok := functions.Base64Functions[name]
+	if !ok {
+		return nil, fmt.Errorf("base64 function %s not found", name)
+	}
+	return f.Func, nil
 }
 
 func getHashFunction(name string) (func([]any) (any, error), error) {
-	return getFunctionByName(functions.HashFunctions, name)
+	f, ok := functions.HashFunctions[name]
+	if !ok {
+		return nil, fmt.Errorf("hash function %s not found", name)
+	}
+	return f.Func, nil
 }
 
 func getFileFunction(name string) (func([]any) (any, error), error) {
-	return getFunctionByName(functions.FileFunctions, name)
+	f, ok := functions.FileFunctions[name]
+	if !ok {
+		return nil, fmt.Errorf("file function %s not found", name)
+	}
+	return f.Func, nil
 }
 
 func getTimeFunction(name string) (func([]any) (any, error), error) {
-	return getFunctionByName(functions.TimeFunctions, name)
+	f, ok := functions.TimeFunctions[name]
+	if !ok {
+		return nil, fmt.Errorf("time function %s not found", name)
+	}
+	return f.Func, nil
 }

--- a/functions/time.go
+++ b/functions/time.go
@@ -30,17 +30,15 @@ func getTimeFormat(format string) string {
 	return format
 }
 
-var TimeFunctions = []*jsonnet.NativeFunction{
-	{
-		Name:   "now",
+var TimeFunctions = map[string]*jsonnet.NativeFunction{
+	"now": {
 		Params: []ast.Identifier{},
 		Func: func(args []any) (any, error) {
 			// Return Unix timestamp as float64 with nanosecond precision
 			return float64(time.Now().UnixNano()) / float64(time.Second), nil
 		},
 	},
-	{
-		Name:   "time_format",
+	"time_format": {
 		Params: []ast.Identifier{"timestamp", "format"},
 		Func: func(args []any) (any, error) {
 			timestamp, ok := args[0].(float64)
@@ -65,4 +63,8 @@ var TimeFunctions = []*jsonnet.NativeFunction{
 			return t.Format(actualFormat), nil
 		},
 	},
+}
+
+func init() {
+	initializeFunctionMap(TimeFunctions)
 }


### PR DESCRIPTION
## Summary
- Convert all function definitions from `[]*jsonnet.NativeFunction{}` slices to `map[string]*jsonnet.NativeFunction{}` for O(1) access and better maintainability
- Remove redundant Name field duplication by auto-setting function names from map keys
- Eliminate inefficient `createFunction()` wrapper function

## Changes
- **All function modules**: Convert slices to maps with function names as keys
- **functions/armed.go**: Update `AllFunctions()` to iterate over maps instead of slices  
- **functions/helpers.go**: Add `initializeFunctionMap()` helper to automatically set Name fields from map keys
- **functions/test_helpers_test.go**: Simplify test helpers to access functions directly from maps
- **Hash function helpers**: Refactor to return function closures instead of full NativeFunction structs

## Benefits
- O(1) function lookup instead of O(n) iteration
- Eliminates redundancy between map keys and Name fields
- More maintainable and cleaner code structure
- Better performance for function access

🤖 Generated with [Claude Code](https://claude.ai/code)