### PR TITLE
Refactor exec functions to use explicit context passing

### DIFF
--- a/functions/armed.go
+++ b/functions/armed.go
@@ -1,13 +1,14 @@
 package functions
 
 import (
+	"context"
+	"fmt"
 	"strings"
 
 	"github.com/google/go-jsonnet"
 )
 
-// AllFunctions returns all native functions in one slice
-func AllFunctions() []*jsonnet.NativeFunction {
+func GenerateAllFunctions(ctx context.Context) []*jsonnet.NativeFunction {
 	var all []*jsonnet.NativeFunction
 
 	// Add functions from maps
@@ -26,7 +27,7 @@ func AllFunctions() []*jsonnet.NativeFunction {
 	for _, f := range TimeFunctions {
 		all = append(all, f)
 	}
-	for _, f := range ExecFunctions {
+	for _, f := range GenerateExecFunctions(ctx) {
 		all = append(all, f)
 	}
 
@@ -34,13 +35,13 @@ func AllFunctions() []*jsonnet.NativeFunction {
 }
 
 // GenerateArmedLib returns the armed library as a string
-func GenerateArmedLib() string {
+func GenerateArmedLib(funcs []*jsonnet.NativeFunction) string {
 	var lines []string
 	lines = append(lines, "{")
 
 	// Add all function definitions
-	for _, f := range AllFunctions() {
-		lines = append(lines, "  "+f.Name+": std.native('"+f.Name+"'),")
+	for _, f := range funcs {
+		lines = append(lines, fmt.Sprintf("  %s: std.native('%s'),", f.Name, f.Name))
 	}
 
 	lines = append(lines, "}")

--- a/functions/armed_test.go
+++ b/functions/armed_test.go
@@ -6,7 +6,8 @@ import (
 )
 
 func TestGenerateArmedLib(t *testing.T) {
-	result := GenerateArmedLib()
+	funcs := GenerateAllFunctions(t.Context())
+	result := GenerateArmedLib(funcs)
 
 	// Verify it contains expected function definitions
 	expectedFunctions := []string{

--- a/functions/exec_context_test.go
+++ b/functions/exec_context_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"testing"
 	"time"
-
-	"github.com/fujiwara/jsonnet-armed/functions"
 )
 
 func TestExecContextCancellation(t *testing.T) {
@@ -16,10 +14,7 @@ func TestExecContextCancellation(t *testing.T) {
 	// Create a cancellable context
 	ctx, cancel := context.WithCancel(context.Background())
 
-	// Set the context for exec functions
-	functions.SetExecContext(ctx)
-
-	execFunc, err := getExecFunction("exec")
+	execFunc, err := getExecFunction(ctx, "exec")
 	if err != nil {
 		t.Fatalf("failed to get exec function: %v", err)
 	}
@@ -62,10 +57,7 @@ func TestExecContextTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	// Set the context for exec functions
-	functions.SetExecContext(ctx)
-
-	execFunc, err := getExecFunction("exec")
+	execFunc, err := getExecFunction(ctx, "exec")
 	if err != nil {
 		t.Fatalf("failed to get exec function: %v", err)
 	}

--- a/functions/exec_lifecycle_test.go
+++ b/functions/exec_lifecycle_test.go
@@ -4,26 +4,26 @@ import (
 	"context"
 	"testing"
 	"time"
-
-	"github.com/fujiwara/jsonnet-armed/functions"
 )
 
 func TestExecContextLifecycle(t *testing.T) {
-	execFunc, err := getExecFunction("exec")
-	if err != nil {
-		t.Fatalf("failed to get exec function: %v", err)
-	}
 
 	// Scenario 1: Set a cancelled context
 	ctx1, cancel1 := context.WithCancel(context.Background())
-	functions.SetExecContext(ctx1)
+	execFunc, err := getExecFunction(ctx1, "exec")
+	if err != nil {
+		t.Fatalf("failed to get exec function: %v", err)
+	}
 	cancel1() // Cancel immediately
 
 	// Wait a bit to ensure cancellation is processed
 	time.Sleep(100 * time.Millisecond)
 
-	// Scenario 2: Reset context (simulating CLI completion)
-	functions.ResetExecContext()
+	ctx2 := t.Context()
+	execFunc, err = getExecFunction(ctx2, "exec")
+	if err != nil {
+		t.Fatalf("failed to get exec function: %v", err)
+	}
 
 	// Scenario 3: Try to execute a simple command (should work, not be affected by previous cancellation)
 	t.Log("Testing exec after context reset...")
@@ -47,22 +47,23 @@ func TestExecContextLifecycle(t *testing.T) {
 }
 
 func TestMultipleCLIExecutions(t *testing.T) {
-	execFunc, err := getExecFunction("exec")
+	// Simulate first CLI execution with timeout
+	ctx1, cancel1 := context.WithTimeout(context.Background(), 1*time.Second)
+	execFunc, err := getExecFunction(ctx1, "exec")
 	if err != nil {
 		t.Fatalf("failed to get exec function: %v", err)
 	}
-
-	// Simulate first CLI execution with timeout
-	ctx1, cancel1 := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel1()
-	functions.SetExecContext(ctx1)
 
 	// Wait for context to timeout
 	time.Sleep(1100 * time.Millisecond)
 
 	// Simulate second CLI execution without timeout (normal case)
-	ctx2 := context.Background()
-	functions.SetExecContext(ctx2)
+	ctx2 := t.Context()
+	execFunc, err = getExecFunction(ctx2, "exec")
+	if err != nil {
+		t.Fatalf("failed to get exec function: %v", err)
+	}
 
 	// This should work normally
 	result, err := execFunc([]any{"echo", []any{"test"}})

--- a/functions/exec_test.go
+++ b/functions/exec_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestExecFunction(t *testing.T) {
-	execFunc, err := getExecFunction("exec")
+	execFunc, err := getExecFunction(t.Context(), "exec")
 	if err != nil {
 		t.Fatalf("failed to get exec function: %v", err)
 	}
@@ -102,7 +102,7 @@ func TestExecFunction(t *testing.T) {
 }
 
 func TestExecWithEnvFunction(t *testing.T) {
-	execWithEnvFunc, err := getExecFunction("exec_with_env")
+	execWithEnvFunc, err := getExecFunction(t.Context(), "exec_with_env")
 	if err != nil {
 		t.Fatalf("failed to get exec_with_env function: %v", err)
 	}
@@ -229,7 +229,7 @@ func TestExecTimeout(t *testing.T) {
 	// Set shorter timeout for testing
 	functions.DefaultExecTimeout = 3 * time.Second
 
-	execFunc, err := getExecFunction("exec")
+	execFunc, err := getExecFunction(t.Context(), "exec")
 	if err != nil {
 		t.Fatalf("failed to get exec function: %v", err)
 	}
@@ -274,7 +274,7 @@ func TestExecTimeoutSIGKILL(t *testing.T) {
 	// Set shorter timeout for testing
 	functions.DefaultExecTimeout = 3 * time.Second
 
-	execFunc, err := getExecFunction("exec")
+	execFunc, err := getExecFunction(t.Context(), "exec")
 	if err != nil {
 		t.Fatalf("failed to get exec function: %v", err)
 	}

--- a/functions/exec_timeout_config_test.go
+++ b/functions/exec_timeout_config_test.go
@@ -22,7 +22,7 @@ func TestCustomExecTimeout(t *testing.T) {
 	// Set a short timeout for testing
 	functions.DefaultExecTimeout = 2 * time.Second
 
-	execFunc, err := getExecFunction("exec")
+	execFunc, err := getExecFunction(t.Context(), "exec")
 	if err != nil {
 		t.Fatalf("failed to get exec function: %v", err)
 	}

--- a/functions/test_helpers_test.go
+++ b/functions/test_helpers_test.go
@@ -1,6 +1,7 @@
 package functions_test
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/fujiwara/jsonnet-armed/functions"
@@ -47,8 +48,8 @@ func getTimeFunction(name string) (func([]any) (any, error), error) {
 	return f.Func, nil
 }
 
-func getExecFunction(name string) (func([]any) (any, error), error) {
-	f, ok := functions.ExecFunctions[name]
+func getExecFunction(ctx context.Context, name string) (func([]any) (any, error), error) {
+	f, ok := functions.GenerateExecFunctions(ctx)[name]
 	if !ok {
 		return nil, fmt.Errorf("exec function %s not found", name)
 	}


### PR DESCRIPTION
## Summary
- Replace global context management with explicit context passing
- Remove thread-unsafe global state (execContext, mutex, Set/Reset functions)
- Pass context through function generation to enable proper timeout and cancellation handling

## Changes
- Changed `AllFunctions()` to `GenerateAllFunctions(ctx)` to accept context parameter
- Changed `ExecFunctions` from static map to `GenerateExecFunctions(ctx)` function
- Updated `executeCommand()` to receive context as parameter
- Modified CLI to pass context through `evaluate()` method
- Updated all tests to use explicit context passing

## Benefits
- Improved thread safety by eliminating global state
- More predictable context lifecycle management
- Clearer code flow with explicit dependencies

🤖 Generated with [Claude Code](https://claude.ai/code)