### PR TITLE
feat: Implement atomic file writing with write-if-changed option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,19 +20,21 @@ go install github.com/fujiwara/jsonnet-armed/cmd/jsonnet-armed@latest
 
 ## Usage
 
+### Command Line Usage
+
 ```bash
 jsonnet-armed [options] <jsonnet-file>
 ```
 
-### Options
+#### Options
 
-- `-o, --output-file <file>`: Write output to file instead of stdout
+- `-o, --output-file <file>`: Write output to file instead of stdout (uses atomic writes to prevent corruption)
 - `-V, --ext-str <key=value>`: Set external string variable (can be repeated)
 - `--ext-code <key=value>`: Set external code variable (can be repeated)
 - `-t, --timeout <duration>`: Timeout for evaluation (e.g., 30s, 5m, 1h)
 - `-v, --version`: Show version and exit
 
-### Examples
+#### Examples
 
 Basic usage:
 ```bash
@@ -109,6 +111,92 @@ local exec_with_env = std.native("exec_with_env");
     platform: if uname.exit_code == 0 then std.strReplace(uname.stdout, "\n", "") else "unknown",
     uptime: if uptime.exit_code == 0 then std.strReplace(uptime.stdout, "\n", "") else "unknown"
   }
+}
+```
+
+### Library Usage
+
+jsonnet-armed can be embedded in your Go application as a configuration loader.
+
+```go
+package main
+
+import (
+    "bytes"
+    "context"
+    "encoding/json"
+    "fmt"
+    "log"
+    
+    armed "github.com/fujiwara/jsonnet-armed"
+)
+
+func main() {
+    // Load configuration from Jsonnet file
+    config, err := LoadConfig("config.jsonnet", map[string]string{
+        "env": "production",
+        "region": "us-west-2",
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+    
+    fmt.Println("Configuration loaded:", config)
+}
+
+func LoadConfig(filename string, vars map[string]string) (map[string]interface{}, error) {
+    // Create CLI instance
+    cli := &armed.CLI{
+        Filename: filename,
+        ExtStr:   vars,
+    }
+    
+    // Capture output in buffer
+    var buf bytes.Buffer
+    cli.SetWriter(&buf)
+    
+    // Execute with context (supports timeout and cancellation)
+    ctx := context.Background()
+    if err := cli.Run(ctx); err != nil {
+        return nil, err
+    }
+    
+    // Parse JSON output
+    var result map[string]interface{}
+    if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+        return nil, err
+    }
+    
+    return result, nil
+}
+```
+
+You can also use timeout and external code variables:
+
+```go
+import "time"
+
+// With timeout
+ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+defer cancel()
+
+cli := &armed.CLI{
+    Filename: "config.jsonnet",
+    ExtStr: map[string]string{
+        "env": "production",
+    },
+    ExtCode: map[string]string{
+        "replicas": "3",
+        "debug": "true",
+    },
+    Timeout: 30 * time.Second,  // Optional: CLI-level timeout
+}
+
+var buf bytes.Buffer
+cli.SetWriter(&buf)
+
+if err := cli.Run(ctx); err != nil {
+    // Handle error
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ jsonnet-armed [options] <jsonnet-file>
 #### Options
 
 - `-o, --output-file <file>`: Write output to file instead of stdout (uses atomic writes to prevent corruption)
+- `--write-if-changed`: Write output file only if content has changed (compares using file size and SHA256 hash)
 - `-V, --ext-str <key=value>`: Set external string variable (can be repeated)
 - `--ext-code <key=value>`: Set external code variable (can be repeated)
 - `-t, --timeout <duration>`: Timeout for evaluation (e.g., 30s, 5m, 1h)
@@ -58,6 +59,9 @@ jsonnet-armed -t 30s config.jsonnet
 
 # Read from stdin with timeout
 echo '{ value: "test" }' | jsonnet-armed -t 10s -
+
+# Write only if content has changed (useful for build tools)
+jsonnet-armed --write-if-changed -o output.json config.jsonnet
 ```
 
 Example Jsonnet file using external variables and native functions:

--- a/cli.go
+++ b/cli.go
@@ -8,11 +8,12 @@ import (
 )
 
 type CLI struct {
-	OutputFile string            `short:"o" name:"output-file" help:"Write to the output file rather than stdout" type:"path"`
-	ExtStr     map[string]string `short:"V" name:"ext-str" help:"Set external string variable (can be repeated)."`
-	ExtCode    map[string]string `name:"ext-code" help:"Set external code variable (can be repeated)."`
-	Timeout    time.Duration     `short:"t" name:"timeout" help:"Timeout for evaluation (e.g., 30s, 5m, 1h)"`
-	Version    kong.VersionFlag  `short:"v" help:"Show version and exit."`
+	OutputFile     string            `short:"o" name:"output-file" help:"Write to the output file rather than stdout" type:"path"`
+	WriteIfChanged bool              `name:"write-if-changed" help:"Write output file only if content has changed"`
+	ExtStr         map[string]string `short:"V" name:"ext-str" help:"Set external string variable (can be repeated)."`
+	ExtCode        map[string]string `name:"ext-code" help:"Set external code variable (can be repeated)."`
+	Timeout        time.Duration     `short:"t" name:"timeout" help:"Timeout for evaluation (e.g., 30s, 5m, 1h)"`
+	Version        kong.VersionFlag  `short:"v" help:"Show version and exit."`
 
 	Filename string `arg:"" name:"filename" help:"Filename or code to execute" type:"path"`
 


### PR DESCRIPTION
## Summary
- Implemented atomic file writing to prevent file corruption
- Added `--write-if-changed` option to skip writing unchanged files
- Optimized for build tools and file watchers

## Changes

### Atomic File Writing
- Write to temporary file first, then atomically rename to target file
- Ensures data integrity with fsync before rename
- Cleans up temporary files on error
- Preserves file permissions (0644)

### Write-If-Changed Option
- New CLI flag `--write-if-changed` to conditionally write output files
- Efficient comparison using:
  1. File size check first (fast path)
  2. SHA256 hash comparison if sizes match
- Uses streaming hash calculation for existing files (memory efficient)
- Preserves file timestamps when content hasn't changed

## Benefits
- Prevents file corruption during write operations
- Reduces unnecessary file system I/O
- Avoids triggering unnecessary rebuilds in build tools
- Improves CI/CD cache efficiency
- Better integration with file watchers

## Test Coverage
- Atomic write tests: concurrent writes, temp file cleanup, permission preservation
- Write-if-changed tests: new file creation, skip unchanged, update changed, size differences
- All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)