### PR TITLE
feat: add stale cache fallback mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ jsonnet-armed [options] <jsonnet-file>
 - `--ext-code <key=value>`: Set external code variable (can be repeated)
 - `-t, --timeout <duration>`: Timeout for evaluation (e.g., 30s, 5m, 1h)
 - `-c, --cache <duration>`: Cache evaluation results for specified duration (e.g., 5m, 1h)
+- `--stale <duration>`: Maximum duration to use stale cache when evaluation fails (e.g., 10m, 2h)
 - `-v, --version`: Show version and exit
 
 #### Examples
@@ -69,6 +70,9 @@ jsonnet-armed --cache 5m config.jsonnet
 
 # Cache for 1 hour with external variables
 jsonnet-armed --cache 1h -V env=production large-config.jsonnet
+
+# Use stale cache fallback for reliability
+jsonnet-armed --cache 5m --stale 10m config.jsonnet
 ```
 
 #### Cache Feature
@@ -79,6 +83,16 @@ The cache feature stores evaluation results to avoid redundant computations:
 - Cache files are stored in `$XDG_CACHE_HOME/jsonnet-armed/` or `$HOME/.cache/jsonnet-armed/`
 - Expired cache entries are automatically cleaned up
 - Useful for expensive computations or frequently accessed configurations
+
+##### Stale Cache Fallback
+
+The `--stale` option provides resilience against evaluation failures:
+
+- When cache expires, evaluation is attempted normally
+- If evaluation fails (syntax error, missing dependencies, etc.), stale cache is used as fallback
+- Stale cache is only used when fresh evaluation fails, not proactively
+- Example: `--cache 5m --stale 10m` caches for 5 minutes, but allows using stale cache up to 10 minutes on errors
+- Helps maintain service availability when configuration sources become temporarily unavailable
 
 Example Jsonnet file using external variables and native functions:
 ```jsonnet

--- a/cache_test.go
+++ b/cache_test.go
@@ -183,7 +183,7 @@ func TestCacheKeyGeneration(t *testing.T) {
 				tt.cli2.Filename = tmpFile2
 			}
 
-			cache := armed.NewCache(time.Minute)
+			cache := armed.NewCache(time.Minute, 0)
 
 			// Read content for both files
 			content1, err := os.ReadFile(tt.cli1.Filename)

--- a/cli.go
+++ b/cli.go
@@ -14,6 +14,7 @@ type CLI struct {
 	ExtCode        map[string]string `name:"ext-code" help:"Set external code variable (can be repeated)."`
 	Timeout        time.Duration     `short:"t" name:"timeout" help:"Timeout for evaluation (e.g., 30s, 5m, 1h)"`
 	Cache          time.Duration     `short:"c" name:"cache" help:"Cache evaluation results for specified duration (e.g., 5m, 1h)"`
+	Stale          time.Duration     `name:"stale" help:"Maximum duration to use stale cache when evaluation fails (e.g., 10m, 2h)"`
 	Version        kong.VersionFlag  `short:"v" help:"Show version and exit."`
 
 	Filename string `arg:"" name:"filename" help:"Filename or code to execute" type:"path"`


### PR DESCRIPTION
## Summary
- Add `--stale` CLI flag for maximum stale cache duration
- Implement stale cache fallback when evaluation fails after cache expiration
- Add structured logging for cache operations and stale cache usage
- Update cache cleanup logic to respect stale duration
- Include comprehensive test coverage

## Background
This feature improves service reliability by allowing cached results to be used when configuration sources become temporarily unavailable. The stale cache is only used as a fallback when fresh evaluation fails, not proactively.

## Usage Example
```bash
# Cache for 5 minutes, but allow stale cache up to 10 minutes on errors
jsonnet-armed --cache 5m --stale 10m config.jsonnet
```

## Implementation Details
- Cache files now support dual TTL: normal cache TTL and stale TTL
- Added `GetWithStale()` method returning (content, isStale, exists)
- Enhanced error handling with structured logging via slog
- Backward compatible: existing `--cache` functionality unchanged

## Test Plan
- [x] Unit tests for cache TTL and stale TTL behavior
- [x] Integration tests for stale cache fallback scenarios
- [x] Warning message verification in tests
- [x] Existing cache functionality regression tests

🤖 Generated with [Claude Code](https://claude.ai/code)