### PR TITLE
feat: Add HTTP/HTTPS output support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ jsonnet-armed [options] <jsonnet-file>
 
 #### Options
 
-- `-o, --output-file <file>`: Write output to file instead of stdout (uses atomic writes to prevent corruption)
+- `-o, --output <target>`: Write output to file or HTTP(S) URL instead of stdout
+  - File output uses atomic writes to prevent corruption
+  - HTTP(S) output sends JSON via POST request with Content-Type: application/json
 - `--write-if-changed`: Write output file only if content has changed (compares using file size and SHA256 hash)
 - `-V, --ext-str <key=value>`: Set external string variable (can be repeated)
 - `--ext-code <key=value>`: Set external code variable (can be repeated)
@@ -50,6 +52,12 @@ jsonnet-armed input.jsonnet
 
 # Write output to file
 jsonnet-armed -o output.json input.jsonnet
+
+# Send output to HTTP endpoint
+jsonnet-armed -o http://localhost:8080/webhook input.jsonnet
+
+# Send output to HTTPS endpoint
+jsonnet-armed -o https://api.example.com/config input.jsonnet
 ```
 
 With external variables:
@@ -77,6 +85,12 @@ jsonnet-armed --cache 1h -V env=production large-config.jsonnet
 
 # Use stale cache fallback for reliability
 jsonnet-armed --cache 5m --stale 10m config.jsonnet
+
+# Send output to webhook with external variables
+jsonnet-armed -o https://webhook.site/unique-url -V env=prod config.jsonnet
+
+# Use with timeout when sending to HTTP endpoint
+jsonnet-armed -o http://localhost:3000/api/config -t 30s config.jsonnet
 ```
 
 #### Cache Feature

--- a/cli.go
+++ b/cli.go
@@ -9,7 +9,7 @@ import (
 )
 
 type CLI struct {
-	OutputFile     string            `short:"o" name:"output-file" help:"Write to the output file rather than stdout" type:"path"`
+	Output         string            `short:"o" name:"output" help:"Write to the output file or http(s) URL rather than stdout"`
 	WriteIfChanged bool              `name:"write-if-changed" help:"Write output file only if content has changed"`
 	ExtStr         map[string]string `short:"V" name:"ext-str" help:"Set external string variable (can be repeated)."`
 	ExtCode        map[string]string `name:"ext-code" help:"Set external code variable (can be repeated)."`


### PR DESCRIPTION
## Summary
- Add ability to send Jsonnet evaluation results to HTTP/HTTPS endpoints
- Replace `--output-file` with `--output` option that accepts both file paths and URLs
- Support POST requests with JSON content and proper headers

## Changes
- Modified CLI option from `--output-file` to `--output` to accept both files and URLs
- Added `writeOutputToHTTP()` function to handle HTTP/HTTPS output
- Send JSON via POST with Content-Type: application/json header
- Include User-Agent header with jsonnet-armed version
- Support context for timeout handling with HTTP requests
- Added comprehensive tests for HTTP and HTTPS output scenarios
- Updated README with HTTP endpoint usage examples

## Test plan
- [x] Added tests for HTTP output with various status codes
- [x] Added tests for HTTPS output (self-signed cert scenario)
- [x] All existing tests pass
- [x] Manual testing with webhook services

🤖 Generated with [Claude Code](https://claude.com/claude-code)