### PR TITLE
Add --stdout flag to output to both file/HTTP and stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ jsonnet-armed [options] <jsonnet-file>
 - `-o, --output <target>`: Write output to file or HTTP(S) URL instead of stdout
   - File output uses atomic writes to prevent corruption
   - HTTP(S) output sends JSON via POST request with Content-Type: application/json
+- `-S, --stdout`: Also write to stdout when using `-o/--output` (can be negated with `--no-stdout`)
 - `--write-if-changed`: Write output file only if content has changed (compares using file size and SHA256 hash)
 - `-V, --ext-str <key=value>`: Set external string variable (can be repeated)
 - `--ext-code <key=value>`: Set external code variable (can be repeated)
@@ -118,11 +119,17 @@ jsonnet-armed input.jsonnet
 # Write output to file
 jsonnet-armed -o output.json input.jsonnet
 
+# Write to file and also display on stdout
+jsonnet-armed -o output.json --stdout input.jsonnet
+
 # Send output to HTTP endpoint
 jsonnet-armed -o http://localhost:8080/webhook input.jsonnet
 
 # Send output to HTTPS endpoint
 jsonnet-armed -o https://api.example.com/config input.jsonnet
+
+# Send to HTTP and also display on stdout
+jsonnet-armed -o https://api.example.com/config -S input.jsonnet
 ```
 
 With external variables:

--- a/cli.go
+++ b/cli.go
@@ -10,6 +10,7 @@ import (
 
 type CLI struct {
 	Output         string            `short:"o" name:"output" help:"Write to the output file or http(s) URL rather than stdout"`
+	Stdout         bool              `short:"S" name:"stdout" help:"Also write to stdout when using -o/--output" negatable:""`
 	WriteIfChanged bool              `name:"write-if-changed" help:"Write output file only if content has changed"`
 	ExtStr         map[string]string `short:"V" name:"ext-str" help:"Set external string variable (can be repeated)."`
 	ExtCode        map[string]string `name:"ext-code" help:"Set external code variable (can be repeated)."`

--- a/main.go
+++ b/main.go
@@ -234,6 +234,11 @@ func (cli *CLI) writeOutput(ctx context.Context, jsonStr string) error {
 		return err
 	}
 
+	// Also write to stdout if enabled
+	if cli.Stdout {
+		defer io.WriteString(os.Stdout, jsonStr)
+	}
+
 	// Check if output is an HTTP(S) URL
 	u, err := url.Parse(out)
 	if err == nil && (u.Scheme == "http" || u.Scheme == "https") {


### PR DESCRIPTION
## Summary
- Added `-S/--stdout` flag that allows writing output to both the specified target and standard output
- Updated README with documentation and examples of the new flag
- The flag can be negated with `--no-stdout`

## Use Case
This feature is useful for debugging and monitoring while still sending output to the intended destination (file or HTTP endpoint). Users can see the output in their terminal while it's also being written to a file or sent to a webhook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)