### PR TITLE
Add filepath manipulation functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ jsonnet-armed provides standard Jsonnet evaluation with external variables suppo
 | `file_stat(filename)` | Get file metadata as object | [📖](#file-functions) |
 | `file_exists(filename)` | Check if file exists | [📖](#file-functions) |
 
+#### Filepath
+| Function | Description | Example |
+|----------|-------------|---------|
+| `basename(path)` | Get base name of a path | [📖](#filepath-functions) |
+| `dirname(path)` | Get directory part of a path | [📖](#filepath-functions) |
+| `extname(path)` | Get file extension (with dot) | [📖](#filepath-functions) |
+| `path_join(elements)` | Join path elements into a single path | [📖](#filepath-functions) |
+
 #### X.509 Certificate
 | Function | Description | Example |
 |----------|-------------|---------|
@@ -1286,6 +1294,42 @@ local file_exists = std.native("file_exists");
     stat: if file_exists(filename) then file_stat(filename) else null,
     safe_size: if file_exists(filename) then file_stat(filename).size else 0
   }
+}
+```
+
+### Filepath Functions
+
+Manipulate file path strings without accessing the filesystem.
+
+Available filepath functions:
+- `basename(path)`: Return the base name (last element) of a path
+- `dirname(path)`: Return the directory part of a path
+- `extname(path)`: Return the file extension including the dot (e.g., `.txt`)
+- `path_join(elements)`: Join an array of path elements into a single path
+
+```jsonnet
+local basename = std.native("basename");
+local dirname = std.native("dirname");
+local extname = std.native("extname");
+local path_join = std.native("path_join");
+
+{
+  // Extract base name from path
+  base: basename("/usr/local/bin/program"),       // "program"
+  base_file: basename("dir/file.txt"),            // "file.txt"
+
+  // Extract directory part
+  dir: dirname("/usr/local/bin/program"),          // "/usr/local/bin"
+  dir_file: dirname("file.txt"),                   // "."
+
+  // Extract file extension
+  ext: extname("config.json"),                     // ".json"
+  ext_none: extname("Makefile"),                   // ""
+  ext_double: extname("archive.tar.gz"),           // ".gz"
+
+  // Join path elements
+  joined: path_join(["/usr", "local", "bin"]),     // "/usr/local/bin"
+  config: path_join(["etc", "app", "config.json"]),// "etc/app/config.json"
 }
 ```
 

--- a/functions/armed.go
+++ b/functions/armed.go
@@ -51,6 +51,9 @@ func GenerateAllFunctions(ctx context.Context) []*jsonnet.NativeFunction {
 	for _, f := range X509Functions {
 		all = append(all, f)
 	}
+	for _, f := range PathFunctions {
+		all = append(all, f)
+	}
 
 	return all
 }

--- a/functions/filepath.go
+++ b/functions/filepath.go
@@ -1,0 +1,64 @@
+package functions
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/google/go-jsonnet"
+	"github.com/google/go-jsonnet/ast"
+)
+
+var PathFunctions = map[string]*jsonnet.NativeFunction{
+	"basename": {
+		Params: []ast.Identifier{"path"},
+		Func: func(args []any) (any, error) {
+			path, ok := args[0].(string)
+			if !ok {
+				return nil, fmt.Errorf("basename: path must be a string")
+			}
+			return filepath.Base(path), nil
+		},
+	},
+	"dirname": {
+		Params: []ast.Identifier{"path"},
+		Func: func(args []any) (any, error) {
+			path, ok := args[0].(string)
+			if !ok {
+				return nil, fmt.Errorf("dirname: path must be a string")
+			}
+			return filepath.Dir(path), nil
+		},
+	},
+	"extname": {
+		Params: []ast.Identifier{"path"},
+		Func: func(args []any) (any, error) {
+			path, ok := args[0].(string)
+			if !ok {
+				return nil, fmt.Errorf("extname: path must be a string")
+			}
+			return filepath.Ext(path), nil
+		},
+	},
+	"path_join": {
+		Params: []ast.Identifier{"elements"},
+		Func: func(args []any) (any, error) {
+			elements, ok := args[0].([]any)
+			if !ok {
+				return nil, fmt.Errorf("path_join: elements must be an array")
+			}
+			parts := make([]string, len(elements))
+			for i, e := range elements {
+				s, ok := e.(string)
+				if !ok {
+					return nil, fmt.Errorf("path_join: element at index %d must be a string", i)
+				}
+				parts[i] = s
+			}
+			return filepath.Join(parts...), nil
+		},
+	},
+}
+
+func init() {
+	initializeFunctionMap(PathFunctions)
+}

--- a/functions/filepath_test.go
+++ b/functions/filepath_test.go
@@ -1,0 +1,167 @@
+package functions_test
+
+import (
+	"testing"
+)
+
+func TestBasename(t *testing.T) {
+	fn, err := getPathFunction("basename")
+	if err != nil {
+		t.Fatalf("failed to get basename function: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		args     []any
+		expected any
+		wantErr  bool
+	}{
+		{name: "absolute path", args: []any{"/usr/local/bin/program"}, expected: "program"},
+		{name: "relative path", args: []any{"dir/file.txt"}, expected: "file.txt"},
+		{name: "filename only", args: []any{"file.txt"}, expected: "file.txt"},
+		{name: "trailing slash", args: []any{"/usr/local/"}, expected: "local"},
+		{name: "root", args: []any{"/"}, expected: "/"},
+		{name: "dotfile", args: []any{"/home/user/.bashrc"}, expected: ".bashrc"},
+		{name: "empty string", args: []any{"."}, expected: "."},
+		{name: "non-string arg", args: []any{123}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := fn(tt.args)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestDirname(t *testing.T) {
+	fn, err := getPathFunction("dirname")
+	if err != nil {
+		t.Fatalf("failed to get dirname function: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		args     []any
+		expected any
+		wantErr  bool
+	}{
+		{name: "absolute path", args: []any{"/usr/local/bin/program"}, expected: "/usr/local/bin"},
+		{name: "relative path", args: []any{"dir/file.txt"}, expected: "dir"},
+		{name: "filename only", args: []any{"file.txt"}, expected: "."},
+		{name: "root file", args: []any{"/file.txt"}, expected: "/"},
+		{name: "nested path", args: []any{"/a/b/c/d"}, expected: "/a/b/c"},
+		{name: "dotfile", args: []any{"/home/user/.bashrc"}, expected: "/home/user"},
+		{name: "non-string arg", args: []any{true}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := fn(tt.args)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestExtname(t *testing.T) {
+	fn, err := getPathFunction("extname")
+	if err != nil {
+		t.Fatalf("failed to get extname function: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		args     []any
+		expected any
+		wantErr  bool
+	}{
+		{name: "simple extension", args: []any{"file.txt"}, expected: ".txt"},
+		{name: "double extension", args: []any{"archive.tar.gz"}, expected: ".gz"},
+		{name: "no extension", args: []any{"Makefile"}, expected: ""},
+		{name: "dotfile", args: []any{".bashrc"}, expected: ".bashrc"},
+		{name: "path with extension", args: []any{"/usr/local/file.json"}, expected: ".json"},
+		{name: "dotfile with extension", args: []any{".config.yaml"}, expected: ".yaml"},
+		{name: "non-string arg", args: []any{nil}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := fn(tt.args)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestPathJoin(t *testing.T) {
+	fn, err := getPathFunction("path_join")
+	if err != nil {
+		t.Fatalf("failed to get path_join function: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		args     []any
+		expected any
+		wantErr  bool
+	}{
+		{name: "two elements", args: []any{[]any{"usr", "local"}}, expected: "usr/local"},
+		{name: "absolute path", args: []any{[]any{"/usr", "local", "bin"}}, expected: "/usr/local/bin"},
+		{name: "with file", args: []any{[]any{"/home", "user", "file.txt"}}, expected: "/home/user/file.txt"},
+		{name: "single element", args: []any{[]any{"file.txt"}}, expected: "file.txt"},
+		{name: "empty array", args: []any{[]any{}}, expected: ""},
+		{name: "with dot", args: []any{[]any{".", "src", "main.go"}}, expected: "src/main.go"},
+		{name: "non-array arg", args: []any{"not-an-array"}, wantErr: true},
+		{name: "non-string element", args: []any{[]any{"valid", 123}}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := fn(tt.args)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}

--- a/functions/test_helpers_test.go
+++ b/functions/test_helpers_test.go
@@ -71,3 +71,11 @@ func getJQFunction(name string) (func([]any) (any, error), error) {
 	}
 	return f.Func, nil
 }
+
+func getPathFunction(name string) (func([]any) (any, error), error) {
+	f, ok := functions.PathFunctions[name]
+	if !ok {
+		return nil, fmt.Errorf("path function %s not found", name)
+	}
+	return f.Func, nil
+}

--- a/integration_test.go
+++ b/integration_test.go
@@ -525,6 +525,43 @@ func TestIntegrationExamples(t *testing.T) {
 			},
 		},
 		{
+			name: "Filepath functions example",
+			jsonnet: `
+			local basename = std.native("basename");
+			local dirname = std.native("dirname");
+			local extname = std.native("extname");
+			local path_join = std.native("path_join");
+			{
+				// basename
+				base_simple: basename("/usr/local/bin/program"),
+				base_file: basename("dir/file.txt"),
+
+				// dirname
+				dir_abs: dirname("/usr/local/bin/program"),
+				dir_file: dirname("file.txt"),
+
+				// extname
+				ext_txt: extname("file.txt"),
+				ext_none: extname("Makefile"),
+				ext_tar_gz: extname("archive.tar.gz"),
+
+				// path_join
+				joined: path_join(["/usr", "local", "bin"]),
+				joined_file: path_join(["home", "user", "file.txt"]),
+			}`,
+			expected: map[string]any{
+				"base_simple": "program",
+				"base_file":   "file.txt",
+				"dir_abs":     "/usr/local/bin",
+				"dir_file":    ".",
+				"ext_txt":     ".txt",
+				"ext_none":    "",
+				"ext_tar_gz":  ".gz",
+				"joined":      "/usr/local/bin",
+				"joined_file": "home/user/file.txt",
+			},
+		},
+		{
 			name: "X509 certificate and private key functions example",
 			jsonnet: `
 			local x509_certificate = std.native("x509_certificate");


### PR DESCRIPTION
## Summary
- Add native functions for filepath manipulation: `basename`, `dirname`, `extname`, `path_join`
- Uses Go's `path/filepath` package for platform-consistent behavior
- Includes unit tests, integration tests, and README documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)